### PR TITLE
Fix a bug + updates.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.1.0-alpha+7
 
+* Updated to `code_builder: ^2.0.0-alpha+3`.
+
+* Fixed a bug where `List<Structure>` types always returned `List<Map>`. [#11](https://github.com/matanlurey/din/issues/11)
+
 * Split most of the Gateway events into `GatewayClient.events`.
 * Renamed `GatewayReady` to `Ready`, and moved to `GatewayEvents.ready`.
 * Add support for resuming a connection (`ApiClient.resume`).

--- a/lib/din.dart
+++ b/lib/din.dart
@@ -20,7 +20,7 @@ export 'src/schema/resources/user.dart' show UsersResource;
 export 'src/schema/structures/channel.dart' show Channel, ChannelType;
 export 'src/schema/structures/gateway.dart'
     show GatewayDispatch, Gateway, GatewayOpcode;
-export 'src/schema/structures/message.dart' show Message;
+export 'src/schema/structures/message.dart' show Message, MessageType;
 export 'src/schema/structures/ready.dart' show Ready;
 export 'src/schema/structures/user.dart' show User;
 export 'src/user_agent.dart' show UserAgent;

--- a/lib/src/schema/resources/channel.g.dart
+++ b/lib/src/schema/resources/channel.g.dart
@@ -8,7 +8,9 @@ part of 'channel.dart';
 
 class _$ChannelsResource implements ChannelsResource {
   _$ChannelsResource(this._restClient);
+
   final RestClient _restClient;
+
   @override
   Future<Channel> getChannel({String id}) {
     return _restClient

--- a/lib/src/schema/resources/gateway.g.dart
+++ b/lib/src/schema/resources/gateway.g.dart
@@ -8,7 +8,9 @@ part of 'gateway.dart';
 
 class _$GatewayResource implements GatewayResource {
   _$GatewayResource(this._restClient);
+
   final RestClient _restClient;
+
   @override
   Future<Gateway> getGateway() {
     return _restClient

--- a/lib/src/schema/resources/user.g.dart
+++ b/lib/src/schema/resources/user.g.dart
@@ -8,7 +8,9 @@ part of 'user.dart';
 
 class _$UsersResource implements UsersResource {
   _$UsersResource(this._restClient);
+
   final RestClient _restClient;
+
   @override
   Future<User> getCurrentUser() {
     return _restClient

--- a/lib/src/schema/structures/channel.g.dart
+++ b/lib/src/schema/structures/channel.g.dart
@@ -8,12 +8,19 @@ part of 'channel.dart';
 
 class _$ChannelBuilder {
   String id;
+
   String name;
+
   String topic;
+
   ChannelType type;
+
   int position;
+
   int bitRate;
+
   int userLimit;
+
   _$Channel _build() {
     return new _$Channel._internal(
       id: id,
@@ -36,11 +43,13 @@ class _$Channel implements Channel {
       this.position,
       this.bitRate,
       this.userLimit});
+
   factory _$Channel(void build(_$ChannelBuilder builder)) {
     final builder = new _$ChannelBuilder();
     build(builder);
     return builder._build();
   }
+
   factory _$Channel.fromJson(Map<String, Object> json) =>
       (new _$ChannelBuilder()
             ..id = json['id'] as String
@@ -51,18 +60,25 @@ class _$Channel implements Channel {
             ..bitRate = json['bitrate'] as int
             ..userLimit = json['userLimit'] as int)
           ._build();
+
   @override
   final String id;
+
   @override
   final String name;
+
   @override
   final String topic;
+
   @override
   final ChannelType type;
+
   @override
   final int position;
+
   @override
   final int bitRate;
+
   @override
   final int userLimit;
 }

--- a/lib/src/schema/structures/gateway.g.dart
+++ b/lib/src/schema/structures/gateway.g.dart
@@ -8,7 +8,9 @@ part of 'gateway.dart';
 
 class _$GatewayBuilder {
   String url;
+
   int shards;
+
   _$Gateway _build() {
     return new _$Gateway._internal(
       url: url,
@@ -19,27 +21,35 @@ class _$GatewayBuilder {
 
 class _$Gateway implements Gateway {
   const _$Gateway._internal({this.url, this.shards});
+
   factory _$Gateway(void build(_$GatewayBuilder builder)) {
     final builder = new _$GatewayBuilder();
     build(builder);
     return builder._build();
   }
+
   factory _$Gateway.fromJson(Map<String, Object> json) =>
       (new _$GatewayBuilder()
             ..url = json['url'] as String
             ..shards = json['shards'] as int)
           ._build();
+
   @override
   final String url;
+
   @override
   final int shards;
 }
 
 class _$GatewayDispatchBuilder {
   GatewayOpcode op;
+
   Object data;
+
   int sequence;
+
   String name;
+
   _$GatewayDispatch _build() {
     return new _$GatewayDispatch._internal(
       op: op,
@@ -53,11 +63,13 @@ class _$GatewayDispatchBuilder {
 class _$GatewayDispatch implements GatewayDispatch {
   const _$GatewayDispatch._internal(
       {this.op, this.data, this.sequence, this.name});
+
   factory _$GatewayDispatch(void build(_$GatewayDispatchBuilder builder)) {
     final builder = new _$GatewayDispatchBuilder();
     build(builder);
     return builder._build();
   }
+
   factory _$GatewayDispatch.fromJson(Map<String, Object> json) =>
       (new _$GatewayDispatchBuilder()
             ..op = GatewayOpcode.values[json['op'] as int]
@@ -65,12 +77,16 @@ class _$GatewayDispatch implements GatewayDispatch {
             ..sequence = json['s'] as int
             ..name = json['t'] as String)
           ._build();
+
   @override
   final GatewayOpcode op;
+
   @override
   final Object data;
+
   @override
   final int sequence;
+
   @override
   final String name;
 }

--- a/lib/src/schema/structures/message.g.dart
+++ b/lib/src/schema/structures/message.g.dart
@@ -8,15 +8,25 @@ part of 'message.dart';
 
 class _$MessageBuilder {
   String id;
+
   String channelId;
+
   String content;
+
   User user;
+
   DateTime timeStamp;
+
   bool mentionsEveryone;
+
   List<User> mentions;
+
   String nonce;
+
   bool isPinned;
+
   MessageType type;
+
   _$Message _build() {
     return new _$Message._internal(
       id: id,
@@ -45,11 +55,13 @@ class _$Message implements Message {
       this.nonce,
       this.isPinned,
       this.type});
+
   factory _$Message(void build(_$MessageBuilder builder)) {
     final builder = new _$MessageBuilder();
     build(builder);
     return builder._build();
   }
+
   factory _$Message.fromJson(Map<String, Object> json) =>
       (new _$MessageBuilder()
             ..id = json['id'] as String
@@ -58,29 +70,41 @@ class _$Message implements Message {
             ..user = new User.fromJson(json['author'] as Map<String, Object>)
             ..timeStamp = DateTime.parse(json['timestamp'] as String)
             ..mentionsEveryone = json['mentions_everyone'] as bool
-            ..mentions = json['mentions'] as List<User>
+            ..mentions = (json['mentions'] as List<Map<String, Object>>)
+                .map((e) => new User.fromJson(e))
+                .toList()
             ..nonce = json['nonce'] as String
             ..isPinned = json['pinned'] as bool
             ..type = MessageType.values[json['type'] as int])
           ._build();
+
   @override
   final String id;
+
   @override
   final String channelId;
+
   @override
   final String content;
+
   @override
   final User user;
+
   @override
   final DateTime timeStamp;
+
   @override
   final bool mentionsEveryone;
+
   @override
   final List<User> mentions;
+
   @override
   final String nonce;
+
   @override
   final bool isPinned;
+
   @override
   final MessageType type;
 }

--- a/lib/src/schema/structures/ready.g.dart
+++ b/lib/src/schema/structures/ready.g.dart
@@ -8,10 +8,15 @@ part of 'ready.dart';
 
 class _$ReadyBuilder {
   int version;
+
   User user;
+
   List<Channel> privateChannels;
+
   String sessionId;
+
   List<String> trace;
+
   _$Ready _build() {
     return new _$Ready._internal(
       version: version,
@@ -30,26 +35,36 @@ class _$Ready implements Ready {
       this.privateChannels,
       this.sessionId,
       this.trace});
+
   factory _$Ready(void build(_$ReadyBuilder builder)) {
     final builder = new _$ReadyBuilder();
     build(builder);
     return builder._build();
   }
+
   factory _$Ready.fromJson(Map<String, Object> json) => (new _$ReadyBuilder()
         ..version = json['v'] as int
         ..user = new User.fromJson(json['user'] as Map<String, Object>)
-        ..privateChannels = json['private_channels'] as List<Channel>
+        ..privateChannels =
+            (json['private_channels'] as List<Map<String, Object>>)
+                .map((e) => new Channel.fromJson(e))
+                .toList()
         ..sessionId = json['session_id'] as String
         ..trace = json['_trade'] as List<String>)
       ._build();
+
   @override
   final int version;
+
   @override
   final User user;
+
   @override
   final List<Channel> privateChannels;
+
   @override
   final String sessionId;
+
   @override
   final List<String> trace;
 }

--- a/lib/src/schema/structures/user.g.dart
+++ b/lib/src/schema/structures/user.g.dart
@@ -8,7 +8,9 @@ part of 'user.dart';
 
 class _$UserBuilder {
   String id;
+
   String name;
+
   _$User _build() {
     return new _$User._internal(
       id: id,
@@ -19,17 +21,21 @@ class _$UserBuilder {
 
 class _$User implements User {
   const _$User._internal({this.id, this.name});
+
   factory _$User(void build(_$UserBuilder builder)) {
     final builder = new _$UserBuilder();
     build(builder);
     return builder._build();
   }
+
   factory _$User.fromJson(Map<String, Object> json) => (new _$UserBuilder()
         ..id = json['id'] as String
         ..name = json['username'] as String)
       ._build();
+
   @override
   final String id;
+
   @override
   final String name;
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,7 @@ dev_dependencies:
   args: ">= 0.13.0 <2.0.0"
   build: "^0.10.0"
   build_runner: ">=0.4.0 <0.6.0"
-  code_builder: "^2.0.0-alpha+1"
+  code_builder: "^2.0.0-alpha+3"
   io: ">=0.1.0 <0.3.0"
   shelf: "^0.7.0"
   shelf_static: "^0.2.0"

--- a/test/api/channel_test.dart
+++ b/test/api/channel_test.dart
@@ -38,5 +38,37 @@ void main() {
       expect(result.bitRate, isNull);
       expect(result.userLimit, isNull);
     });
+
+    test('getMessages', () async {
+      responses['GET fake.api/channels/1234/messages'] = [
+        {
+          'id': '1234',
+          'content': 'Hello World',
+          'author': <String, Object>{},
+          'timestamp': new DateTime.now().toIso8601String(),
+          'mentions_everyone': false,
+          'mentions': <Map<String, Object>>[
+            <String, Object>{},
+          ],
+          'nonce': '1234abcd',
+          'pinned': true,
+          'type': din.MessageType.auto.index,
+        },
+      ];
+      final result = await channels.getMessages(channelId: '1234');
+      expect(result, hasLength(1));
+      expect(result.first, const isInstanceOf<din.Message>());
+      final message = result.first;
+      expect(message.id, '1234');
+      expect(message.content, 'Hello World');
+      expect(message.user, const isInstanceOf<din.User>());
+      expect(message.timeStamp, isNotNull);
+      expect(message.mentionsEveryone, isFalse);
+      expect(message.mentions, hasLength(1));
+      expect(message.mentions.first, const isInstanceOf<din.User>());
+      expect(message.nonce, '1234abcd');
+      expect(message.isPinned, isTrue);
+      expect(message.type, din.MessageType.auto);
+    });
   });
 }

--- a/tool/codegen/resource.dart
+++ b/tool/codegen/resource.dart
@@ -26,7 +26,7 @@ class ResourceGenerator extends GeneratorForAnnotation<meta.Resource> {
     return new Class((b) {
       _writeClassDefaults(b, element);
       _implementEndpoints(b, urlRoot, element);
-    }).accept(const DartEmitter()).toString();
+    }).accept(new DartEmitter.scoped()).toString();
   }
 
   static void _writeClassDefaults(ClassBuilder b, ClassElement clazz) => b
@@ -60,14 +60,16 @@ class ResourceGenerator extends GeneratorForAnnotation<meta.Resource> {
     }
   }
 
+  static const _$override = const Reference('override', 'dart:core');
+
   static Method _generateEndpoint(
     String urlRoot,
     ConstantReader endPoint,
     MethodElement method,
   ) =>
       new Method((b) => b
-        ..annotations.add(new Annotation(
-            (b) => b..code = new Code((b) => b..code = 'override')))
+        ..annotations
+            .add(new Annotation((b) => b..code = _$override.annotation().code))
         ..name = method.name
         ..returns = new Reference(method.returnType.displayName)
         ..optionalParameters
@@ -75,8 +77,7 @@ class ResourceGenerator extends GeneratorForAnnotation<meta.Resource> {
               ..name = m.name
               ..named = true
               ..type = new Reference(m.type.displayName))))
-        ..body = new Code((b) => b
-          ..code = '''
+        ..body = new Code.scope((_) => '''
           return _restClient.request(
             url: '${_getUrl(urlRoot, endPoint.read('path').listValue)}',
             method: '${endPoint.read('method').stringValue}',


### PR DESCRIPTION
Closes #11.

## 0.1.0-alpha+7

* Updated to `code_builder: ^2.0.0-alpha+3`.

* Fixed a bug where `List<Structure>` types always returned `List<Map>`. [#11](https://github.com/matanlurey/din/issues/11)

* Split most of the Gateway events into `GatewayClient.events`.
* Renamed `GatewayReady` to `Ready`, and moved to `GatewayEvents.ready`.
* Add support for resuming a connection (`ApiClient.resume`).